### PR TITLE
nfcf

### DIFF
--- a/firmware/targets/f7/api_symbols.csv
+++ b/firmware/targets/f7/api_symbols.csv
@@ -1,5 +1,5 @@
 entry,status,name,type,params
-Version,+,8.2,,
+Version,+,8.3,,
 Header,+,applications/services/bt/bt_service/bt.h,,
 Header,+,applications/services/cli/cli.h,,
 Header,+,applications/services/cli/cli_vcp.h,,
@@ -1829,7 +1829,7 @@ Function,+,menu_set_selected_item,void,"Menu*, uint32_t"
 Function,-,mf_classic_auth_attempt,_Bool,"FuriHalNfcTxRxContext*, MfClassicAuthContext*, uint64_t"
 Function,-,mf_classic_auth_init_context,void,"MfClassicAuthContext*, uint8_t"
 Function,-,mf_classic_authenticate,_Bool,"FuriHalNfcTxRxContext*, uint8_t, uint64_t, MfClassicKey"
-Function,-,mf_classic_check_card_type,_Bool,"uint8_t, uint8_t, uint8_t"
+Function,-,mf_classic_check_card_type,_Bool,FuriHalNfcADevData*
 Function,-,mf_classic_dict_add_key,_Bool,"MfClassicDict*, uint8_t*"
 Function,-,mf_classic_dict_add_key_str,_Bool,"MfClassicDict*, FuriString*"
 Function,-,mf_classic_dict_alloc,MfClassicDict*,MfClassicDictType
@@ -1847,7 +1847,7 @@ Function,-,mf_classic_dict_is_key_present,_Bool,"MfClassicDict*, uint8_t*"
 Function,-,mf_classic_dict_is_key_present_str,_Bool,"MfClassicDict*, FuriString*"
 Function,-,mf_classic_dict_rewind,_Bool,MfClassicDict*
 Function,-,mf_classic_emulator,_Bool,"MfClassicEmulator*, FuriHalNfcTxRxContext*"
-Function,-,mf_classic_get_classic_type,MfClassicType,"int8_t, uint8_t, uint8_t"
+Function,-,mf_classic_get_classic_type,MfClassicType,FuriHalNfcADevData*
 Function,-,mf_classic_get_read_sectors_and_keys,void,"MfClassicData*, uint8_t*, uint8_t*"
 Function,-,mf_classic_get_sector_by_block,uint8_t,uint8_t
 Function,-,mf_classic_get_sector_trailer_block_num_by_sector,uint8_t,uint8_t
@@ -1881,7 +1881,7 @@ Function,-,mf_df_cat_file,void,"MifareDesfireFile*, FuriString*"
 Function,-,mf_df_cat_free_mem,void,"MifareDesfireFreeMemory*, FuriString*"
 Function,-,mf_df_cat_key_settings,void,"MifareDesfireKeySettings*, FuriString*"
 Function,-,mf_df_cat_version,void,"MifareDesfireVersion*, FuriString*"
-Function,-,mf_df_check_card_type,_Bool,"uint8_t, uint8_t, uint8_t"
+Function,-,mf_df_check_card_type,_Bool,FuriHalNfcADevData*
 Function,-,mf_df_clear,void,MifareDesfireData*
 Function,-,mf_df_parse_get_application_ids_response,_Bool,"uint8_t*, uint16_t, MifareDesfireApplication**"
 Function,-,mf_df_parse_get_file_ids_response,_Bool,"uint8_t*, uint16_t, MifareDesfireFile**"
@@ -1904,7 +1904,7 @@ Function,-,mf_df_prepare_read_data,uint16_t,"uint8_t*, uint8_t, uint32_t, uint32
 Function,-,mf_df_prepare_read_records,uint16_t,"uint8_t*, uint8_t, uint32_t, uint32_t"
 Function,-,mf_df_prepare_select_application,uint16_t,"uint8_t*, uint8_t[3]"
 Function,-,mf_df_read_card,_Bool,"FuriHalNfcTxRxContext*, MifareDesfireData*"
-Function,-,mf_ul_check_card_type,_Bool,"uint8_t, uint8_t, uint8_t"
+Function,-,mf_ul_check_card_type,_Bool,FuriHalNfcADevData*
 Function,-,mf_ul_is_full_capture,_Bool,MfUltralightData*
 Function,-,mf_ul_prepare_emulation,void,"MfUltralightEmulator*, MfUltralightData*"
 Function,-,mf_ul_prepare_emulation_response,_Bool,"uint8_t*, uint16_t, uint8_t*, uint16_t*, uint32_t*, void*"

--- a/lib/nfc/parsers/plantain_4k_parser.c
+++ b/lib/nfc/parsers/plantain_4k_parser.c
@@ -71,8 +71,7 @@ bool plantain_4k_parser_read(NfcWorker* nfc_worker, FuriHalNfcTxRxContext* tx_rx
 
     MfClassicReader reader = {};
     FuriHalNfcADevData* nfc_a_data = &nfc_worker->dev_data->nfc_data.a_data;
-    reader.type =
-        mf_classic_get_classic_type(nfc_a_data->atqa[0], nfc_a_data->atqa[1], nfc_a_data->sak);
+    reader.type = mf_classic_get_classic_type(nfc_a_data);
     for(size_t i = 0; i < COUNT_OF(plantain_keys_4k); i++) {
         mf_classic_reader_add_sector(
             &reader,

--- a/lib/nfc/parsers/plantain_parser.c
+++ b/lib/nfc/parsers/plantain_parser.c
@@ -46,8 +46,7 @@ bool plantain_parser_read(NfcWorker* nfc_worker, FuriHalNfcTxRxContext* tx_rx) {
 
     MfClassicReader reader = {};
     FuriHalNfcADevData* nfc_a_data = &nfc_worker->dev_data->nfc_data.a_data;
-    reader.type =
-        mf_classic_get_classic_type(nfc_a_data->atqa[0], nfc_a_data->atqa[1], nfc_a_data->sak);
+    reader.type = mf_classic_get_classic_type(nfc_a_data);
     for(size_t i = 0; i < COUNT_OF(plantain_keys); i++) {
         mf_classic_reader_add_sector(
             &reader, plantain_keys[i].sector, plantain_keys[i].key_a, plantain_keys[i].key_b);

--- a/lib/nfc/parsers/troika_4k_parser.c
+++ b/lib/nfc/parsers/troika_4k_parser.c
@@ -68,8 +68,7 @@ bool troika_4k_parser_read(NfcWorker* nfc_worker, FuriHalNfcTxRxContext* tx_rx) 
 
     MfClassicReader reader = {};
     FuriHalNfcADevData* nfc_a_data = &nfc_worker->dev_data->nfc_data.a_data;
-    reader.type =
-        mf_classic_get_classic_type(nfc_a_data->atqa[0], nfc_a_data->atqa[1], nfc_a_data->sak);
+    reader.type = mf_classic_get_classic_type(nfc_a_data);
     for(size_t i = 0; i < COUNT_OF(troika_4k_keys); i++) {
         mf_classic_reader_add_sector(
             &reader, troika_4k_keys[i].sector, troika_4k_keys[i].key_a, troika_4k_keys[i].key_b);

--- a/lib/nfc/parsers/troika_parser.c
+++ b/lib/nfc/parsers/troika_parser.c
@@ -44,8 +44,7 @@ bool troika_parser_read(NfcWorker* nfc_worker, FuriHalNfcTxRxContext* tx_rx) {
 
     MfClassicReader reader = {};
     FuriHalNfcADevData* nfc_a_data = &nfc_worker->dev_data->nfc_data.a_data;
-    reader.type =
-        mf_classic_get_classic_type(nfc_a_data->atqa[0], nfc_a_data->atqa[1], nfc_a_data->sak);
+    reader.type = mf_classic_get_classic_type(nfc_a_data);
 
     for(size_t i = 0; i < COUNT_OF(troika_keys); i++) {
         mf_classic_reader_add_sector(

--- a/lib/nfc/parsers/two_cities.c
+++ b/lib/nfc/parsers/two_cities.c
@@ -72,8 +72,7 @@ bool two_cities_parser_read(NfcWorker* nfc_worker, FuriHalNfcTxRxContext* tx_rx)
 
     MfClassicReader reader = {};
     FuriHalNfcADevData* nfc_a_data = &nfc_worker->dev_data->nfc_data.a_data;
-    reader.type =
-        mf_classic_get_classic_type(nfc_a_data->atqa[0], nfc_a_data->atqa[1], nfc_a_data->sak);
+    reader.type = mf_classic_get_classic_type(nfc_a_data);
     for(size_t i = 0; i < COUNT_OF(two_cities_keys_4k); i++) {
         mf_classic_reader_add_sector(
             &reader,

--- a/lib/nfc/protocols/mifare_classic.c
+++ b/lib/nfc/protocols/mifare_classic.c
@@ -351,7 +351,10 @@ static bool mf_classic_is_allowed_access(
     }
 }
 
-bool mf_classic_check_card_type(uint8_t ATQA0, uint8_t ATQA1, uint8_t SAK) {
+bool mf_classic_check_card_type(FuriHalNfcADevData* data) {
+    uint8_t ATQA0 = data->atqa[0];
+    uint8_t ATQA1 = data->atqa[1];
+    uint8_t SAK = data->sak;
     if((ATQA0 == 0x44 || ATQA0 == 0x04) && (SAK == 0x08 || SAK == 0x88 || SAK == 0x09)) {
         return true;
     } else if((ATQA0 == 0x01) && (ATQA1 == 0x0F) && (SAK == 0x01)) {
@@ -364,7 +367,10 @@ bool mf_classic_check_card_type(uint8_t ATQA0, uint8_t ATQA1, uint8_t SAK) {
     }
 }
 
-MfClassicType mf_classic_get_classic_type(int8_t ATQA0, uint8_t ATQA1, uint8_t SAK) {
+MfClassicType mf_classic_get_classic_type(FuriHalNfcADevData* data) {
+    uint8_t ATQA0 = data->atqa[0];
+    uint8_t ATQA1 = data->atqa[1];
+    uint8_t SAK = data->sak;
     if((ATQA0 == 0x44 || ATQA0 == 0x04) && (SAK == 0x08 || SAK == 0x88 || SAK == 0x09)) {
         return MfClassicType1k;
     } else if((ATQA0 == 0x01) && (ATQA1 == 0x0F) && (SAK == 0x01)) {

--- a/lib/nfc/protocols/mifare_classic.c
+++ b/lib/nfc/protocols/mifare_classic.c
@@ -352,7 +352,6 @@ static bool mf_classic_is_allowed_access(
 }
 
 bool mf_classic_check_card_type(uint8_t ATQA0, uint8_t ATQA1, uint8_t SAK) {
-    UNUSED(ATQA1);
     if((ATQA0 == 0x44 || ATQA0 == 0x04) && (SAK == 0x08 || SAK == 0x88 || SAK == 0x09)) {
         return true;
     } else if((ATQA0 == 0x01) && (ATQA1 == 0x0F) && (SAK == 0x01)) {

--- a/lib/nfc/protocols/mifare_classic.c
+++ b/lib/nfc/protocols/mifare_classic.c
@@ -365,7 +365,6 @@ bool mf_classic_check_card_type(uint8_t ATQA0, uint8_t ATQA1, uint8_t SAK) {
 }
 
 MfClassicType mf_classic_get_classic_type(int8_t ATQA0, uint8_t ATQA1, uint8_t SAK) {
-    UNUSED(ATQA1);
     if((ATQA0 == 0x44 || ATQA0 == 0x04) && (SAK == 0x08 || SAK == 0x88 || SAK == 0x09)) {
         return MfClassicType1k;
     } else if((ATQA0 == 0x01) && (ATQA1 == 0x0F) && (SAK == 0x01)) {

--- a/lib/nfc/protocols/mifare_classic.h
+++ b/lib/nfc/protocols/mifare_classic.h
@@ -92,9 +92,9 @@ typedef struct {
 
 const char* mf_classic_get_type_str(MfClassicType type);
 
-bool mf_classic_check_card_type(uint8_t ATQA0, uint8_t ATQA1, uint8_t SAK);
+bool mf_classic_check_card_type(FuriHalNfcADevData* data);
 
-MfClassicType mf_classic_get_classic_type(int8_t ATQA0, uint8_t ATQA1, uint8_t SAK);
+MfClassicType mf_classic_get_classic_type(FuriHalNfcADevData* data);
 
 uint8_t mf_classic_get_total_sectors_num(MfClassicType type);
 

--- a/lib/nfc/protocols/mifare_common.c
+++ b/lib/nfc/protocols/mifare_common.c
@@ -1,6 +1,10 @@
 #include "mifare_common.h"
+#include "furi_hal_nfc.h"
 
-MifareType mifare_common_get_type(uint8_t ATQA0, uint8_t ATQA1, uint8_t SAK) {
+MifareType mifare_common_get_type(FuriHalNfcADevData* data) {
+    uint8_t ATQA0 = data->atqa[0];
+    uint8_t ATQA1 = data->atqa[1];
+    uint8_t SAK = data->sak;
     MifareType type = MifareTypeUnknown;
 
     if((ATQA0 == 0x44) && (ATQA1 == 0x00) && (SAK == 0x00)) {

--- a/lib/nfc/protocols/mifare_common.h
+++ b/lib/nfc/protocols/mifare_common.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stdint.h>
+#include "furi_hal_nfc.h"
 
 typedef enum {
     MifareTypeUnknown,
@@ -9,4 +10,4 @@ typedef enum {
     MifareTypeDesfire,
 } MifareType;
 
-MifareType mifare_common_get_type(uint8_t ATQA0, uint8_t ATQA1, uint8_t SAK);
+MifareType mifare_common_get_type(FuriHalNfcADevData* data);

--- a/lib/nfc/protocols/mifare_desfire.c
+++ b/lib/nfc/protocols/mifare_desfire.c
@@ -233,7 +233,11 @@ void mf_df_cat_file(MifareDesfireFile* file, FuriString* out) {
     }
 }
 
-bool mf_df_check_card_type(uint8_t ATQA0, uint8_t ATQA1, uint8_t SAK) {
+bool mf_df_check_card_type(FuriHalNfcADevData* data) {
+    uint8_t ATQA0 = data->atqa[0];
+    uint8_t ATQA1 = data->atqa[1];
+    uint8_t SAK = data->sak;
+
     return ATQA0 == 0x44 && ATQA1 == 0x03 && SAK == 0x20;
 }
 

--- a/lib/nfc/protocols/mifare_desfire.h
+++ b/lib/nfc/protocols/mifare_desfire.h
@@ -128,7 +128,7 @@ void mf_df_cat_application_info(MifareDesfireApplication* app, FuriString* out);
 void mf_df_cat_application(MifareDesfireApplication* app, FuriString* out);
 void mf_df_cat_file(MifareDesfireFile* file, FuriString* out);
 
-bool mf_df_check_card_type(uint8_t ATQA0, uint8_t ATQA1, uint8_t SAK);
+bool mf_df_check_card_type(FuriHalNfcADevData* data);
 
 uint16_t mf_df_prepare_get_version(uint8_t* dest);
 bool mf_df_parse_get_version_response(uint8_t* buf, uint16_t len, MifareDesfireVersion* out);

--- a/lib/nfc/protocols/mifare_ultralight.c
+++ b/lib/nfc/protocols/mifare_ultralight.c
@@ -33,11 +33,12 @@ uint32_t mf_ul_pwdgen_amiibo(FuriHalNfcDevData* data) {
     return pwd;
 }
 
-bool mf_ul_check_card_type(uint8_t ATQA0, uint8_t ATQA1, uint8_t SAK) {
-    if((ATQA0 == 0x44) && (ATQA1 == 0x00) && (SAK == 0x00)) {
-        return true;
-    }
-    return false;
+bool mf_ul_check_card_type(FuriHalNfcADevData* data) {
+    uint8_t ATQA0 = data->atqa[0];
+    uint8_t ATQA1 = data->atqa[1];
+    uint8_t SAK = data->sak;
+
+    return ((ATQA0 == 0x44) && (ATQA1 == 0x00) && (SAK == 0x00));
 }
 
 void mf_ul_reset(MfUltralightData* data) {

--- a/lib/nfc/protocols/mifare_ultralight.h
+++ b/lib/nfc/protocols/mifare_ultralight.h
@@ -200,7 +200,7 @@ typedef struct {
 
 void mf_ul_reset(MfUltralightData* data);
 
-bool mf_ul_check_card_type(uint8_t ATQA0, uint8_t ATQA1, uint8_t SAK);
+bool mf_ul_check_card_type(FuriHalNfcADevData* data);
 
 bool mf_ultralight_read_version(
     FuriHalNfcTxRxContext* tx_rx,


### PR DESCRIPTION
- mf_classic_check_card_type: ATQA1 is used
- mf_classic_get_classic_type: ATQA1 is used
- use FuriHalNfcADevData instead of using each of its fields in function calls

# What's new

- [ Describe changes here ]

# Verification 

- [ Describe how to verify changes ]

# Checklist (For Reviewer)

- [ ] PR has description of feature/bug or link to Confluence/Jira task
- [ ] Description contains actions to verify feature/bugfix
- [ ] I've built this code, uploaded it to the device and verified feature/bugfix
